### PR TITLE
Backed authenticator

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -11,7 +11,7 @@ export interface Authenticator {
 	 * @param password Password.
 	 * @return true if user exists with that password, false otherwise.
 	 */
-	authenticate(username: string, password: string): boolean;
+	authenticate(username: string, password: string): boolean | Promise<boolean>;
 }
 
 /**
@@ -59,5 +59,16 @@ export class PlainAuthenticator implements Authenticator {
 			throw new TypeError("invalid password");
 		}
 		return this._users.get(username) === password;
+	}
+}
+
+export type BackedAuthenticateHandler = (username: string, password: string) => boolean | Promise<boolean>;
+export class BackedAuthenticator implements Authenticator {
+	private onAuthenticate: BackedAuthenticateHandler;
+	constructor(_onAuthenticate: BackedAuthenticateHandler) {
+		this.onAuthenticate = _onAuthenticate;
+	}
+	public async authenticate(username: string, password: string): Promise<boolean> {
+		return await this.onAuthenticate(username, password);
 	}
 }

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -61,14 +61,3 @@ export class PlainAuthenticator implements Authenticator {
 		return this._users.get(username) === password;
 	}
 }
-
-export type BackedAuthenticateHandler = (username: string, password: string) => boolean | Promise<boolean>;
-export class BackedAuthenticator implements Authenticator {
-	private onAuthenticate: BackedAuthenticateHandler;
-	constructor(_onAuthenticate: BackedAuthenticateHandler) {
-		this.onAuthenticate = _onAuthenticate;
-	}
-	public async authenticate(username: string, password: string): Promise<boolean> {
-		return await this.onAuthenticate(username, password);
-	}
-}

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -143,10 +143,6 @@ export class Hub {
 		this._authenticator = authenticator || new PlainAuthenticator();
 	}
 
-	public setAuthenticator(authenticator: Authenticator): void {
-		this._authenticator = authenticator;
-	}
-
 	public getAuthenticator(): Authenticator {
 		return this._authenticator;
 	}

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -204,9 +204,6 @@ export class Hub {
 	}
 
 	public async authenticate(username: string, password: string): Promise<boolean> {
-		if (!this._authenticator) {
-			throw new Error("missing authenticator");
-		}
 		return await this._authenticator.authenticate(username, password);
 	}
 }

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -203,11 +203,11 @@ export class Hub {
 		return pubsub.isDestination(n) ? n : undefined;
 	}
 
-	public authenticate(username: string, password: string): boolean {
+	public async authenticate(username: string, password: string): Promise<boolean> {
 		if (!this._authenticator) {
 			throw new Error("missing authenticator");
 		}
-		return this._authenticator.authenticate(username, password);
+		return await this._authenticator.authenticate(username, password);
 	}
 }
 

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -7,7 +7,7 @@
  * turn used by e.g. TcpConnection, WSConnection, and LocalClient.
  */
 
-import { Authenticator, PlainAuthenticator } from "./authenticator";
+import { Authenticator } from "./authenticator";
 import Dict from "./dict";
 import { getMatcher, Matcher } from "./match";
 import * as pubsub from "./pubsub";
@@ -139,12 +139,8 @@ export class Hub {
 	private _rights: Dict<PartialPermissions> = new Dict<PartialPermissions>();
 	private _storage: Storage<any> | undefined;
 
-	constructor(authenticator?: Authenticator) {
-		this._authenticator = authenticator || new PlainAuthenticator();
-	}
-
-	public getAuthenticator(): Authenticator {
-		return this._authenticator;
+	constructor(authenticator: Authenticator) {
+		this._authenticator = authenticator;
 	}
 
 	public setRights(rights: UserRights): void {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -200,7 +200,7 @@ export class Hub {
 	}
 
 	public async authenticate(username: string, password: string): Promise<boolean> {
-		return await this._authenticator.authenticate(username, password);
+		return this._authenticator.authenticate(username, password);
 	}
 }
 

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -7,7 +7,7 @@
  * turn used by e.g. TcpConnection, WSConnection, and LocalClient.
  */
 
-import { Authenticator } from "./authenticator";
+import { Authenticator, PlainAuthenticator } from "./authenticator";
 import Dict from "./dict";
 import { getMatcher, Matcher } from "./match";
 import * as pubsub from "./pubsub";
@@ -135,12 +135,20 @@ export class Authorizer {
 
 export class Hub {
 	private _nodes: Dict<pubsub.BaseNode> = new Dict<pubsub.BaseNode>();
-	private _authenticator: Authenticator | undefined;
+	private _authenticator: Authenticator;
 	private _rights: Dict<PartialPermissions> = new Dict<PartialPermissions>();
 	private _storage: Storage<any> | undefined;
 
+	constructor(authenticator?: Authenticator) {
+		this._authenticator = authenticator || new PlainAuthenticator();
+	}
+
 	public setAuthenticator(authenticator: Authenticator): void {
 		this._authenticator = authenticator;
+	}
+
+	public getAuthenticator(): Authenticator {
+		return this._authenticator;
 	}
 
 	public setRights(rights: UserRights): void {

--- a/src/hubclient.ts
+++ b/src/hubclient.ts
@@ -294,7 +294,7 @@ export class HubClient extends events.EventEmitter {
 		};
 	}
 
-	private _handleLogin(msg: protocol.LoginCommand): protocol.LoginAckResponse | undefined {
+	private async _handleLogin(msg: protocol.LoginCommand): Promise<protocol.LoginAckResponse | undefined> {
 		if (this._username !== undefined) {
 			// Wouldn't really be a problem for now, but may be in
 			// the future if e.g. different users have different quota
@@ -302,7 +302,7 @@ export class HubClient extends events.EventEmitter {
 			throw new Error("already logged in");
 		}
 
-		const authenticated = this._hub.authenticate(msg.username, msg.password);
+		const authenticated = await this._hub.authenticate(msg.username, msg.password);
 		if (!authenticated) {
 			throw new Error("authentication failed");
 		}

--- a/src/hubclient.ts
+++ b/src/hubclient.ts
@@ -153,16 +153,16 @@ export class HubClient extends events.EventEmitter {
 			}
 			switch (msg.type) {
 				case "publish":
-					response = await this._handlePublish(msg);
+					response = this._handlePublish(msg);
 					break;
 				case "subscribe":
-					response = await this._handleSubscribe(msg);
+					response = this._handleSubscribe(msg);
 					break;
 				case "unsubscribe":
-					response = await this._handleUnsubscribe(msg);
+					response = this._handleUnsubscribe(msg);
 					break;
 				case "ping":
-					response = await this._handlePing(msg);
+					response = this._handlePing(msg);
 					break;
 				case "login":
 					response = await this._handleLogin(msg);

--- a/src/hubclient.ts
+++ b/src/hubclient.ts
@@ -142,7 +142,7 @@ export class HubClient extends events.EventEmitter {
 	 *
 	 * @param msg Command to process.
 	 */
-	public processCommand(msg: protocol.Command): void {
+	public async processCommand(msg: protocol.Command): Promise<void> {
 		let response: protocol.Response | undefined;
 		try {
 			if (typeof msg !== "object") {
@@ -153,19 +153,19 @@ export class HubClient extends events.EventEmitter {
 			}
 			switch (msg.type) {
 				case "publish":
-					response = this._handlePublish(msg);
+					response = await this._handlePublish(msg);
 					break;
 				case "subscribe":
-					response = this._handleSubscribe(msg);
+					response = await this._handleSubscribe(msg);
 					break;
 				case "unsubscribe":
-					response = this._handleUnsubscribe(msg);
+					response = await this._handleUnsubscribe(msg);
 					break;
 				case "ping":
-					response = this._handlePing(msg);
+					response = await this._handlePing(msg);
 					break;
 				case "login":
-					response = this._handleLogin(msg);
+					response = await this._handleLogin(msg);
 					break;
 				default:
 					throw new Error(`unknown command '${msg!.type}'`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,7 @@ import MClient from "./nodeclient";
 export default MClient;
 export * from "./nodeclient";
 export { MServer } from "./nodeserver";
+export { Hub } from "./hub";
+export { BackedAuthenticator, PlainAuthenticator } from "./authenticator";
 
 export { default as Message } from "./message";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,6 @@ export default MClient;
 export * from "./nodeclient";
 export { MServer } from "./nodeserver";
 export { Hub } from "./hub";
-export { BackedAuthenticator, PlainAuthenticator } from "./authenticator";
+export { Authenticator, PlainAuthenticator } from "./authenticator";
 
 export { default as Message } from "./message";

--- a/src/localclient.ts
+++ b/src/localclient.ts
@@ -38,11 +38,8 @@ class LocalConnection extends events.EventEmitter implements Connection {
 	 * @return Promise that resolves when transmit is accepted (i.e. not necessarily
 	 * arrived at other side, can be e.g. queued).
 	 */
-	public send(data: protocol.Command): Promise<void> {
-		return new Promise<void>((resolve) => {
-			this._hubClient.processCommand(data);
-			resolve(undefined);
-		});
+	public async send(data: protocol.Command): Promise<void> {
+		await this._hubClient.processCommand(data);
 	}
 
 	/**

--- a/src/nodeserver.ts
+++ b/src/nodeserver.ts
@@ -146,11 +146,16 @@ export class MServer {
 	}
 
 	private setAuthenticator({ users }: NormalizedConfig): void {
-		const authenticator = new PlainAuthenticator();
-		Object.keys(users).forEach((username: string) => {
-			authenticator.setUser(username, users[username]);
-		});
-		this.hub.setAuthenticator(authenticator);
+		const authenticator = this.hub.getAuthenticator();
+		const usernames = Object.keys(users);
+		if (usernames.length > 0) {
+			if (!(authenticator instanceof PlainAuthenticator)) {
+				throw new Error(`Hub uses an external authenticator. Use that to add users`);
+			}
+			usernames.forEach((username: string) => {
+				authenticator.setUser(username, users[username]);
+			});
+		}
 	}
 
 	// Set up user permissions

--- a/src/nodeserver.ts
+++ b/src/nodeserver.ts
@@ -111,6 +111,7 @@ nodeClassMap.TopicState = TopicStore;
 
 export class MServer {
 	private hub: Hub;
+	private plainAuth: PlainAuthenticator;
 	private normalizedConfig: NormalizedConfig;
 	private logger: Logger | undefined = undefined;
 	private connectionId = 0;
@@ -118,9 +119,10 @@ export class MServer {
 		normalizedConfig: NormalizedConfig,
 		hub?: Hub
 	) {
-		this.hub = hub || new Hub();
+		this.plainAuth = new PlainAuthenticator();
+		this.hub = hub || new Hub(this.plainAuth);
 		this.normalizedConfig = normalizedConfig;
-		this.setAuthenticator(normalizedConfig);
+		this.setUsers(normalizedConfig);
 		this.setPermissions(normalizedConfig);
 		this.instantiateNodes(normalizedConfig);
 		this.setupBindings(normalizedConfig);
@@ -145,17 +147,11 @@ export class MServer {
 		}
 	}
 
-	private setAuthenticator({ users }: NormalizedConfig): void {
-		const authenticator = this.hub.getAuthenticator();
+	private setUsers({ users }: NormalizedConfig): void {
 		const usernames = Object.keys(users);
-		if (usernames.length > 0) {
-			if (!(authenticator instanceof PlainAuthenticator)) {
-				throw new Error(`Hub uses an external authenticator. Use that to add users`);
-			}
-			usernames.forEach((username: string) => {
-				authenticator.setUser(username, users[username]);
-			});
-		}
+		usernames.forEach((username: string) => {
+			this.plainAuth.setUser(username, users[username]);
+		});
 	}
 
 	// Set up user permissions

--- a/src/transports/tcpconnection.ts
+++ b/src/transports/tcpconnection.ts
@@ -44,7 +44,7 @@ export class TcpConnection {
 		this._socket.destroy(); // will cause close event, which causes client close
 	}
 
-	private _handleSocketData(chunk: string): void {
+	private async _handleSocketData(chunk: string): Promise<void> {
 		// Add new chunk to buffer, start looking for lines
 		// in buffer
 		this._buffer += chunk;
@@ -65,7 +65,7 @@ export class TcpConnection {
 			log.debug(`[ ${this._name} ] command ${line}`);
 			try {
 				const cmd: protocol.Command = JSON.parse(line);
-				this._client.processCommand(cmd);
+				await this._client.processCommand(cmd);
 			} catch (e) {
 				log.error(`[ ${this._name} ] protocol error ${e}`);
 				this._handleClientResponse({

--- a/src/transports/wsconnection.ts
+++ b/src/transports/wsconnection.ts
@@ -42,7 +42,15 @@ export class WSConnection {
 		this._socket.close(); // will cause close event, which causes client close
 	}
 
-	private async _handleSocketMessage(data: string): Promise<void> {
+	private _handleProtocolError(e: Error): void {
+		log.error(`[ ${this._name} ] protocol error ${e}`);
+		this._handleClientResponse({
+			type: "error",
+			message: `protocol error: ${e}`,
+		});
+	}
+
+	private _handleSocketMessage(data: string): void {
 		if (data === "") {
 			// Ignore empty lines
 			return;
@@ -50,13 +58,10 @@ export class WSConnection {
 		log.debug(`[ ${this._name} ] command ${data}`);
 		try {
 			const cmd: protocol.Command = JSON.parse(data);
-			await this._client.processCommand(cmd);
+			this._client.processCommand(cmd)
+				.catch((e: Error) => this._handleProtocolError(e));
 		} catch (e) {
-			log.error(`[ ${this._name} ] protocol error ${e}`);
-			this._handleClientResponse({
-				type: "error",
-				message: `protocol error: ${e}`,
-			});
+			this._handleProtocolError(e);
 		}
 	}
 }

--- a/src/transports/wsconnection.ts
+++ b/src/transports/wsconnection.ts
@@ -42,7 +42,7 @@ export class WSConnection {
 		this._socket.close(); // will cause close event, which causes client close
 	}
 
-	private _handleSocketMessage(data: string): void {
+	private async _handleSocketMessage(data: string): Promise<void> {
 		if (data === "") {
 			// Ignore empty lines
 			return;
@@ -50,7 +50,7 @@ export class WSConnection {
 		log.debug(`[ ${this._name} ] command ${data}`);
 		try {
 			const cmd: protocol.Command = JSON.parse(data);
-			this._client.processCommand(cmd);
+			await this._client.processCommand(cmd);
 		} catch (e) {
 			log.error(`[ ${this._name} ] protocol error ${e}`);
 			this._handleClientResponse({

--- a/test/nodes/test-headerStore.ts
+++ b/test/nodes/test-headerStore.ts
@@ -4,6 +4,7 @@
 
 import { expect } from "chai";
 
+import { PlainAuthenticator } from "../../src/authenticator";
 import { Dict } from "../../src/dict";
 import Hub from "../../src/hub";
 import { LocalClient } from "../../src/localclient";
@@ -35,7 +36,8 @@ export class MemStorage<T> implements Storage<T> {
 }
 
 function createHub(storage: Storage<any>): Hub {
-	const hub = new Hub();
+	const auth = new PlainAuthenticator();
+	const hub = new Hub(auth);
 	hub.add(new HeaderStore("default"));
 	hub.setRights({ "": true });
 	hub.setStorage(storage);

--- a/test/test-auth.ts
+++ b/test/test-auth.ts
@@ -47,9 +47,8 @@ describe("auth", (): void => {
 	}
 
 	beforeEach(() => {
-		hub = new Hub();
 		auth = new PlainAuthenticator();
-		hub.setAuthenticator(auth);
+		hub = new Hub(auth);
 		hub.add(new Exchange("default"));
 		return createAndConnectClient();
 	});

--- a/test/test-hub.ts
+++ b/test/test-hub.ts
@@ -4,6 +4,7 @@
 
 import { expect } from "chai";
 
+import { PlainAuthenticator } from "../src/authenticator";
 import Hub from "../src/hub";
 import LocalClient from "../src/localclient";
 import { Message } from "../src/message";
@@ -21,7 +22,8 @@ describe("hub", (): void => {
 	}
 
 	beforeEach(() => {
-		hub = new Hub();
+		const auth = new PlainAuthenticator();
+		hub = new Hub(auth);
 		hub.add(new Exchange("default"));
 		hub.setRights({
 			"": true,

--- a/test/test-hubclient.ts
+++ b/test/test-hubclient.ts
@@ -16,11 +16,10 @@ describe("HubClient", (): void => {
 	let client: HubClient;
 
 	beforeEach(() => {
-		const hub = new Hub();
-
 		const auth = new PlainAuthenticator();
+		const hub = new Hub(auth);
+
 		auth.setUser("foo", "bar");
-		hub.setAuthenticator(auth);
 
 		hub.setRights({
 			"": { publish: false, subscribe: true },

--- a/test/test-localclient.ts
+++ b/test/test-localclient.ts
@@ -7,13 +7,15 @@
 
 import { expect } from "chai";
 
+import { PlainAuthenticator } from "../src/authenticator";
 import Hub from "../src/hub";
 import { LocalClient } from "../src/localclient";
 import Message from "../src/message";
 import Exchange from "../src/nodes/exchange";
 
 function createHub(): Hub {
-	const hub = new Hub();
+	const auth = new PlainAuthenticator();
+	const hub = new Hub(auth);
 	hub.setRights({ "": true });
 	hub.add(new Exchange("default"));
 	return hub;

--- a/test/test-nodeclient.ts
+++ b/test/test-nodeclient.ts
@@ -22,6 +22,7 @@ class TestServer {
 	public connectionCount: number = 0;
 
 	private _port: number;
+	private _auth: PlainAuthenticator;
 	private _hub: Hub;
 	private _server: http.Server;
 	private _wss: ws.Server;
@@ -30,15 +31,14 @@ class TestServer {
 
 	constructor(port: number) {
 		this._port = port;
-		this._hub = new Hub();
+		this._auth = new PlainAuthenticator();
+		this._hub = new Hub(this._auth);
 		this._server = http.createServer();
 		this._wss = new ws.Server({ server: <any>this._server, path: "/" });
 	}
 
 	public start(): Promise<void> {
-		const auth = new PlainAuthenticator();
-		auth.setUser("foo", "bar");
-		this._hub.setAuthenticator(auth);
+		this._auth.setUser("foo", "bar");
 		return this._hub.init().then(() => this._startTransport());
 	}
 


### PR DESCRIPTION
More flexible authenthicator, to allow for a db backed authentication

Let me know what you think. I guess a similar pattern could be applied to authorization as well.
Furthermore, I'd probably want to simplify the config for the mserver, as it now needs the full blown normalized config, which is not ideal. But all these are separate pull requests